### PR TITLE
Fix inconsistencies between wrapper and web API

### DIFF
--- a/src/common/src/com/jinxservers/alphavantage/alphaIntelligence/request/AlphaIntelligenceRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/alphaIntelligence/request/AlphaIntelligenceRequest.kt
@@ -10,7 +10,7 @@ public class AlphaIntelligenceRequest(
     private val alphaVantage: AlphaVantage
 ) {
 
-    public suspend fun getMarketNews(tickers: List<String> = emptyList(), topics: List<Topic> = emptyList(), timeFrom: String = "", timeTo: String = "", sort: Sort = Sort.LATEST, limit: Int = 50): MarketNews {
+    public suspend fun getMarketNews(tickers: List<String>? = null, topics: List<Topic>? = null, timeFrom: String? = null, timeTo: String? = null, sort: Sort? = null, limit: Int? = null): MarketNews {
         return alphaVantage.request(MarketNewsRequest(tickers, topics, timeFrom, timeTo, sort, limit))
     }
 

--- a/src/common/src/com/jinxservers/alphavantage/alphaIntelligence/request/MarketNewsRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/alphaIntelligence/request/MarketNewsRequest.kt
@@ -7,30 +7,34 @@ import com.jinxservers.alphavantage.util.Topic
 import io.ktor.http.*
 
 internal class MarketNewsRequest(
-    tickers: List<String> = emptyList(),
-    topics: List<Topic> = emptyList(),
-    timeFrom: String = "",
-    timeTo: String = "",
-    sort: Sort = Sort.LATEST,
-    limit: Int = 50
+    tickers: List<String>?,
+    topics: List<Topic>?,
+    timeFrom: String?,
+    timeTo: String?,
+    sort: Sort?,
+    limit: Int?
     ) : Request<MarketNews>(
     urlBuilder = URLBuilder().apply {
         parameters.apply {
             append("function", "NEWS_SENTIMENT")
-            if (tickers.isNotEmpty()) {
+            if (tickers != null) {
                 append("tickers", tickers.joinToString(","))
             }
-            if (topics.isNotEmpty()) {
+            if (topics != null) {
                 append("topics", topics.joinToString(",") { it.value })
             }
-            if (timeFrom.isNotBlank()) {
+            if (timeFrom != null) {
                 append("time_from", timeFrom)
             }
-            if (timeTo.isNotBlank()) {
+            if (timeTo != null) {
                 append("time_to", timeTo)
             }
-            append("sort", sort.name)
-            append("limit", limit.toString())
+            if (sort != null) {
+                append("sort", sort.name)
+            }
+            if (limit != null) {
+                append("limit", limit.toString())
+            }
         }
     }
 )

--- a/src/common/src/com/jinxservers/alphavantage/alphaIntelligence/request/MarketNewsRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/alphaIntelligence/request/MarketNewsRequest.kt
@@ -7,11 +7,11 @@ import com.jinxservers.alphavantage.util.Topic
 import io.ktor.http.*
 
 internal class MarketNewsRequest(
-    tickers: List<String>?,
-    topics: List<Topic>?,
-    timeFrom: String?,
-    timeTo: String?,
-    sort: Sort?,
+    tickers: List<String>? = null,
+    topics: List<Topic>? = null,
+    timeFrom: String? = null,
+    timeTo: String? = null,
+    sort: Sort? = null,
     limit: Int?
     ) : Request<MarketNews>(
     urlBuilder = URLBuilder().apply {

--- a/src/common/src/com/jinxservers/alphavantage/commodity/request/CommodityObjectRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/commodity/request/CommodityObjectRequest.kt
@@ -7,7 +7,7 @@ import io.ktor.http.*
 
 internal class CommodityObjectRequest(
     function: String,
-    interval: Interval?,
+    interval: Interval? = null,
 ) : Request<CommodityObject>(
     urlBuilder = URLBuilder().apply {
         parameters.apply {

--- a/src/common/src/com/jinxservers/alphavantage/commodity/request/CommodityObjectRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/commodity/request/CommodityObjectRequest.kt
@@ -7,12 +7,14 @@ import io.ktor.http.*
 
 internal class CommodityObjectRequest(
     function: String,
-    interval: Interval,
+    interval: Interval?,
 ) : Request<CommodityObject>(
     urlBuilder = URLBuilder().apply {
         parameters.apply {
             append("function", function)
-            append("interval", interval.value())
+            if (interval != null) {
+                append("interval", interval.value())
+            }
         }
     }
 )

--- a/src/common/src/com/jinxservers/alphavantage/commodity/request/CommodityRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/commodity/request/CommodityRequest.kt
@@ -1,62 +1,56 @@
 package com.jinxservers.alphavantage.commodity.request
 
 import com.jinxservers.alphavantage.AlphaVantage
-import com.jinxservers.alphavantage.Request
 import com.jinxservers.alphavantage.commodity.response.CommodityObject
-import com.jinxservers.alphavantage.forex.request.CurrencyExchangeRateRequest
-import com.jinxservers.alphavantage.forex.response.CurrencyExchangeRate
 import com.jinxservers.alphavantage.util.CommodityInterval
 import com.jinxservers.alphavantage.util.LongInterval
-import com.jinxservers.alphavantage.util.ShortInterval
-import io.ktor.http.*
-
 
 
 public class CommodityRequest internal constructor(
     private val alphaVantage: AlphaVantage
 ) {
 
-    public suspend fun getCrudeOilWTI(interval: LongInterval = LongInterval.MONTHLY): CommodityObject {
+    public suspend fun getCrudeOilWTI(interval: LongInterval? = null): CommodityObject {
         return alphaVantage.request(CommodityObjectRequest("WTI", interval))
     }
 
-    public suspend fun getCrudeOilBrent(interval: LongInterval = LongInterval.MONTHLY): CommodityObject {
+    public suspend fun getCrudeOilBrent(interval: LongInterval? = null): CommodityObject {
         return alphaVantage.request(CommodityObjectRequest("BRENT", interval))
     }
 
-    public suspend fun getNaturalGas(interval: LongInterval = LongInterval.MONTHLY): CommodityObject {
+    public suspend fun getNaturalGas(interval: LongInterval? = null): CommodityObject {
         return alphaVantage.request(CommodityObjectRequest("NATURAL_GAS", interval))
     }
 
-    public suspend fun getCopper(interval: CommodityInterval = CommodityInterval.MONTHLY): CommodityObject {
+    public suspend fun getCopper(interval: CommodityInterval? = null): CommodityObject {
         return alphaVantage.request(CommodityObjectRequest("COPPER", interval))
     }
 
-    public suspend fun getAluminum(interval: CommodityInterval = CommodityInterval.MONTHLY): CommodityObject {
+    public suspend fun getAluminum(interval: CommodityInterval? = null): CommodityObject {
         return alphaVantage.request(CommodityObjectRequest("ALUMINUM", interval))
     }
 
-    public suspend fun getWheat(interval: CommodityInterval = CommodityInterval.MONTHLY): CommodityObject {
+    public suspend fun getWheat(interval: CommodityInterval? = null): CommodityObject {
         return alphaVantage.request(CommodityObjectRequest("WHEAT", interval))
     }
 
-    public suspend fun getCorn(interval: CommodityInterval = CommodityInterval.MONTHLY): CommodityObject {
+    public suspend fun getCorn(interval: CommodityInterval? = null): CommodityObject {
         return alphaVantage.request(CommodityObjectRequest("CORN", interval))
     }
 
-    public suspend fun getCotton(interval: CommodityInterval = CommodityInterval.MONTHLY): CommodityObject {
+    public suspend fun getCotton(interval: CommodityInterval? = null): CommodityObject {
         return alphaVantage.request(CommodityObjectRequest("COTTON", interval))
     }
 
-    public suspend fun getSugar(interval: CommodityInterval = CommodityInterval.MONTHLY): CommodityObject {
+    public suspend fun getSugar(interval: CommodityInterval? = null): CommodityObject {
         return alphaVantage.request(CommodityObjectRequest("SUGAR", interval))
     }
 
-    public suspend fun getCoffee(interval: CommodityInterval = CommodityInterval.MONTHLY): CommodityObject {
+    public suspend fun getCoffee(interval: CommodityInterval? = null): CommodityObject {
         return alphaVantage.request(CommodityObjectRequest("COFFEE", interval))
     }
 
-    public suspend fun getAll(interval: CommodityInterval = CommodityInterval.MONTHLY): CommodityObject {
+    public suspend fun getAll(interval: CommodityInterval? = null): CommodityObject {
         return alphaVantage.request(CommodityObjectRequest("ALL_COMMODITIES", interval))
     }
 }

--- a/src/common/src/com/jinxservers/alphavantage/core/request/CoreRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/core/request/CoreRequest.kt
@@ -9,15 +9,15 @@ public class CoreRequest internal constructor(
     private val alphaVantage: AlphaVantage
 ) {
 
-    public suspend fun getIntraday(symbol: String, interval: ShortInterval, adjusted: Boolean = true, extendedHours: Boolean = true, month: String = "", outputSize: OutputSize = OutputSize.COMPACT): CoreIntraday {
+    public suspend fun getIntraday(symbol: String, interval: ShortInterval, adjusted: Boolean? = null, extendedHours: Boolean? = null, month: String? = null, outputSize: OutputSize? = null): CoreIntraday {
         return alphaVantage.request(IntradayRequest(symbol, interval, adjusted, extendedHours, month, outputSize))
     }
 
-    public suspend fun getDaily(symbol: String, outputSize: OutputSize = OutputSize.COMPACT): CoreDaily {
+    public suspend fun getDaily(symbol: String, outputSize: OutputSize? = null): CoreDaily {
         return alphaVantage.request(DailyRequest(symbol, outputSize))
     }
 
-    public suspend fun getDailyAdjusted(symbol: String, outputSize: OutputSize = OutputSize.COMPACT): CoreDailyAdjusted {
+    public suspend fun getDailyAdjusted(symbol: String, outputSize: OutputSize? = null): CoreDailyAdjusted {
         return alphaVantage.request(DailyAdjustedRequest(symbol, outputSize))
     }
 

--- a/src/common/src/com/jinxservers/alphavantage/core/request/DailyAdjustedRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/core/request/DailyAdjustedRequest.kt
@@ -7,13 +7,15 @@ import io.ktor.http.*
 
 internal class DailyAdjustedRequest(
     symbol: String,
-    outputSize: OutputSize = OutputSize.COMPACT,
+    outputSize: OutputSize?,
 ): Request<CoreDailyAdjusted>(
     urlBuilder = URLBuilder().apply {
         parameters.apply {
             append("function", "TIME_SERIES_DAILY_ADJUSTED")
             append("symbol", symbol)
-            append("outputsize", outputSize.size)
+            if (outputSize != null) {
+                append("outputsize", outputSize.size)
+            }
         }
     }
 )

--- a/src/common/src/com/jinxservers/alphavantage/core/request/DailyAdjustedRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/core/request/DailyAdjustedRequest.kt
@@ -7,7 +7,7 @@ import io.ktor.http.*
 
 internal class DailyAdjustedRequest(
     symbol: String,
-    outputSize: OutputSize?,
+    outputSize: OutputSize? = null,
 ): Request<CoreDailyAdjusted>(
     urlBuilder = URLBuilder().apply {
         parameters.apply {

--- a/src/common/src/com/jinxservers/alphavantage/core/request/DailyRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/core/request/DailyRequest.kt
@@ -7,13 +7,15 @@ import io.ktor.http.*
 
 internal class DailyRequest(
     symbol: String,
-    outputSize: OutputSize = OutputSize.COMPACT,
+    outputSize: OutputSize?,
 ): Request<CoreDaily>(
     urlBuilder = URLBuilder().apply {
         parameters.apply {
             append("function", "TIME_SERIES_DAILY")
             append("symbol", symbol)
-            append("outputsize", outputSize.size)
+            if (outputSize != null) {
+                append("outputsize", outputSize.size)
+            }
         }
     }
 )

--- a/src/common/src/com/jinxservers/alphavantage/core/request/DailyRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/core/request/DailyRequest.kt
@@ -7,7 +7,7 @@ import io.ktor.http.*
 
 internal class DailyRequest(
     symbol: String,
-    outputSize: OutputSize?,
+    outputSize: OutputSize? = null,
 ): Request<CoreDaily>(
     urlBuilder = URLBuilder().apply {
         parameters.apply {

--- a/src/common/src/com/jinxservers/alphavantage/core/request/IntradayRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/core/request/IntradayRequest.kt
@@ -10,10 +10,10 @@ import io.ktor.http.*
 internal class IntradayRequest(
     symbol: String,
     interval: ShortInterval,
-    adjusted: Boolean?,
-    extendedHours: Boolean?,
-    month: String?,
-    outputSize: OutputSize?,
+    adjusted: Boolean? = null,
+    extendedHours: Boolean? = null,
+    month: String? = null,
+    outputSize: OutputSize? = null,
 ) : Request<CoreIntraday>(
     urlBuilder = URLBuilder().apply {
         parameters.apply {

--- a/src/common/src/com/jinxservers/alphavantage/core/request/IntradayRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/core/request/IntradayRequest.kt
@@ -10,22 +10,28 @@ import io.ktor.http.*
 internal class IntradayRequest(
     symbol: String,
     interval: ShortInterval,
-    adjusted: Boolean = true,
-    extendedHours: Boolean = true,
-    month: String = "",
-    outputSize: OutputSize = OutputSize.COMPACT,
+    adjusted: Boolean?,
+    extendedHours: Boolean?,
+    month: String?,
+    outputSize: OutputSize?,
 ) : Request<CoreIntraday>(
     urlBuilder = URLBuilder().apply {
         parameters.apply {
             append("function", "TIME_SERIES_INTRADAY")
             append("symbol", symbol)
             append("interval", interval.value())
-            append("adjusted", adjusted.toString())
-            append("extended_hours", extendedHours.toString())
-            if (month.isNotBlank()) {
+            if (adjusted != null) {
+                append("adjusted", adjusted.toString())
+            }
+            if (extendedHours != null) {
+                append("extended_hours", extendedHours.toString())
+            }
+            if (month != null) {
                 append("month", month)
             }
-            append("outputsize", outputSize.size)
+            if (outputSize != null) {
+                append("outputsize", outputSize.size)
+            }
         }
     }
 )

--- a/src/common/src/com/jinxservers/alphavantage/crypto/request/CryptoRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/crypto/request/CryptoRequest.kt
@@ -1,12 +1,11 @@
 package com.jinxservers.alphavantage.crypto.request
 
 import com.jinxservers.alphavantage.AlphaVantage
+import com.jinxservers.alphavantage.crypto.response.CryptoDaily
+import com.jinxservers.alphavantage.crypto.response.CryptoIntraday
+import com.jinxservers.alphavantage.crypto.response.CryptoMonthly
+import com.jinxservers.alphavantage.crypto.response.CryptoWeekly
 import com.jinxservers.alphavantage.forex.request.CurrencyExchangeRateRequest
-import com.jinxservers.alphavantage.crypto.request.DailyRequest
-import com.jinxservers.alphavantage.crypto.request.IntradayRequest
-import com.jinxservers.alphavantage.crypto.request.MonthlyRequest
-import com.jinxservers.alphavantage.crypto.request.WeeklyRequest
-import com.jinxservers.alphavantage.crypto.response.*
 import com.jinxservers.alphavantage.forex.response.CurrencyExchangeRate
 import com.jinxservers.alphavantage.util.ShortInterval
 
@@ -18,7 +17,7 @@ public class CryptoRequest internal constructor(
         return alphaVantage.request(CurrencyExchangeRateRequest(fromCurrency, toCurrency))
     }
 
-    public suspend fun getIntraday(fromSymbol: String, toSymbol: String, interval: ShortInterval, outputSize: String = "compact"): CryptoIntraday {
+    public suspend fun getIntraday(fromSymbol: String, toSymbol: String, interval: ShortInterval, outputSize: String? = null): CryptoIntraday {
         return alphaVantage.request(IntradayRequest(fromSymbol, toSymbol, interval, outputSize))
     }
 

--- a/src/common/src/com/jinxservers/alphavantage/crypto/request/IntradayRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/crypto/request/IntradayRequest.kt
@@ -9,7 +9,7 @@ internal class IntradayRequest(
     symbol: String,
     market: String,
     interval: ShortInterval,
-    outputSize: String?
+    outputSize: String? = null
 ) : Request<CryptoIntraday>(
     urlBuilder = URLBuilder().apply {
         parameters.apply {

--- a/src/common/src/com/jinxservers/alphavantage/crypto/request/IntradayRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/crypto/request/IntradayRequest.kt
@@ -2,7 +2,6 @@ package com.jinxservers.alphavantage.crypto.request
 
 import com.jinxservers.alphavantage.Request
 import com.jinxservers.alphavantage.crypto.response.CryptoIntraday
-import com.jinxservers.alphavantage.forex.response.ForexIntraday
 import com.jinxservers.alphavantage.util.ShortInterval
 import io.ktor.http.*
 
@@ -10,7 +9,7 @@ internal class IntradayRequest(
     symbol: String,
     market: String,
     interval: ShortInterval,
-    outputSize: String = "compact"
+    outputSize: String?
 ) : Request<CryptoIntraday>(
     urlBuilder = URLBuilder().apply {
         parameters.apply {
@@ -18,7 +17,9 @@ internal class IntradayRequest(
             append("symbol", symbol)
             append("market", market)
             append("interval", interval.value())
-            append("outputsize", outputSize)
+            if (outputSize != null) {
+                append("outputsize", outputSize)
+            }
         }
     }
 )

--- a/src/common/src/com/jinxservers/alphavantage/economic/request/CPIRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/economic/request/CPIRequest.kt
@@ -6,12 +6,14 @@ import com.jinxservers.alphavantage.util.CpiInterval
 import io.ktor.http.*
 
 internal class CPIRequest(
-    interval: CpiInterval = CpiInterval.MONTHLY
+    interval: CpiInterval?
 ) : Request<EconomicObject>(
     urlBuilder = URLBuilder().apply {
         parameters.apply {
             append("function", "CPI")
-            append("interval", interval.value())
+            if (interval != null) {
+                append("interval", interval.value())
+            }
         }
     }
 )

--- a/src/common/src/com/jinxservers/alphavantage/economic/request/CPIRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/economic/request/CPIRequest.kt
@@ -6,7 +6,7 @@ import com.jinxservers.alphavantage.util.CpiInterval
 import io.ktor.http.*
 
 internal class CPIRequest(
-    interval: CpiInterval?
+    interval: CpiInterval? = null
 ) : Request<EconomicObject>(
     urlBuilder = URLBuilder().apply {
         parameters.apply {

--- a/src/common/src/com/jinxservers/alphavantage/economic/request/EconomicRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/economic/request/EconomicRequest.kt
@@ -11,7 +11,7 @@ public class EconomicRequest internal constructor(
     private val alphaVantage: AlphaVantage
 ) {
 
-    public suspend fun getRealGdp(interval: GdpInterval = GdpInterval.ANNUAL): EconomicObject {
+    public suspend fun getRealGdp(interval: GdpInterval? = null): EconomicObject {
         return alphaVantage.request(RealGDPRequest(interval))
     }
 
@@ -19,15 +19,15 @@ public class EconomicRequest internal constructor(
         return alphaVantage.request(EconomicObjectRequest("REAL_GDP_PER_CAPITA"))
     }
 
-    public suspend fun getTreasuryYield(interval: LongInterval = LongInterval.MONTHLY, maturity: Maturity = Maturity.TEN_YEAR): EconomicObject {
+    public suspend fun getTreasuryYield(interval: LongInterval? = null, maturity: Maturity? = null): EconomicObject {
         return alphaVantage.request(TreasuryYieldRequest(interval, maturity))
     }
 
-    public suspend fun getFederalFundsRate(interval: LongInterval = LongInterval.MONTHLY): EconomicObject {
+    public suspend fun getFederalFundsRate(interval: LongInterval? = null): EconomicObject {
         return alphaVantage.request(FederalFundsRateRequest(interval))
     }
 
-    public suspend fun getCPI(interval: CpiInterval = CpiInterval.MONTHLY): EconomicObject {
+    public suspend fun getCPI(interval: CpiInterval? = null): EconomicObject {
         return alphaVantage.request(CPIRequest(interval))
     }
 

--- a/src/common/src/com/jinxservers/alphavantage/economic/request/FederalFundsRateRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/economic/request/FederalFundsRateRequest.kt
@@ -6,7 +6,7 @@ import com.jinxservers.alphavantage.util.LongInterval
 import io.ktor.http.*
 
 internal class FederalFundsRateRequest(
-    interval: LongInterval?
+    interval: LongInterval? = null
 ) : Request<EconomicObject>(
     urlBuilder = URLBuilder().apply {
         parameters.apply {

--- a/src/common/src/com/jinxservers/alphavantage/economic/request/FederalFundsRateRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/economic/request/FederalFundsRateRequest.kt
@@ -6,12 +6,14 @@ import com.jinxservers.alphavantage.util.LongInterval
 import io.ktor.http.*
 
 internal class FederalFundsRateRequest(
-    interval: LongInterval = LongInterval.MONTHLY
+    interval: LongInterval?
 ) : Request<EconomicObject>(
     urlBuilder = URLBuilder().apply {
         parameters.apply {
             append("function", "FEDERAL_FUNDS_RATE")
-            append("interval", interval.value())
+            if (interval != null) {
+                append("interval", interval.value())
+            }
         }
     }
 )

--- a/src/common/src/com/jinxservers/alphavantage/economic/request/RealGDPRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/economic/request/RealGDPRequest.kt
@@ -7,12 +7,14 @@ import io.ktor.http.*
 
 
 internal class RealGDPRequest(
-    interval: GdpInterval = GdpInterval.ANNUAL
+    interval: GdpInterval?
 ) : Request<EconomicObject>(
     urlBuilder = URLBuilder().apply {
         parameters.apply {
             append("function", "REAL_GDP")
-            append("interval", interval.value())
+            if (interval != null) {
+                append("interval", interval.value())
+            }
         }
     }
 )

--- a/src/common/src/com/jinxservers/alphavantage/economic/request/RealGDPRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/economic/request/RealGDPRequest.kt
@@ -7,7 +7,7 @@ import io.ktor.http.*
 
 
 internal class RealGDPRequest(
-    interval: GdpInterval?
+    interval: GdpInterval? = null
 ) : Request<EconomicObject>(
     urlBuilder = URLBuilder().apply {
         parameters.apply {

--- a/src/common/src/com/jinxservers/alphavantage/economic/request/TreasuryYieldRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/economic/request/TreasuryYieldRequest.kt
@@ -7,8 +7,8 @@ import com.jinxservers.alphavantage.util.Maturity
 import io.ktor.http.*
 
 internal class TreasuryYieldRequest(
-    interval: LongInterval?,
-    maturity: Maturity?
+    interval: LongInterval? = null,
+    maturity: Maturity? = null
 ) : Request<EconomicObject>(
     urlBuilder = URLBuilder().apply {
         parameters.apply {

--- a/src/common/src/com/jinxservers/alphavantage/economic/request/TreasuryYieldRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/economic/request/TreasuryYieldRequest.kt
@@ -7,14 +7,18 @@ import com.jinxservers.alphavantage.util.Maturity
 import io.ktor.http.*
 
 internal class TreasuryYieldRequest(
-    interval: LongInterval = LongInterval.MONTHLY,
-    maturity: Maturity = Maturity.TEN_YEAR
+    interval: LongInterval?,
+    maturity: Maturity?
 ) : Request<EconomicObject>(
     urlBuilder = URLBuilder().apply {
         parameters.apply {
             append("function", "TREASURY_YIELD")
-            append("interval", interval.value())
-            append("maturity", maturity.value)
+            if (interval != null) {
+                append("interval", interval.value())
+            }
+            if (maturity != null) {
+                append("maturity", maturity.value)
+            }
         }
     }
 )

--- a/src/common/src/com/jinxservers/alphavantage/forex/request/DailyRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/forex/request/DailyRequest.kt
@@ -8,7 +8,7 @@ import io.ktor.http.*
 internal class DailyRequest(
     fromSymbol: String,
     toSymbol: String,
-    outputSize: OutputSize?
+    outputSize: OutputSize? = null
 ) : Request<ForexDaily>(
     urlBuilder = URLBuilder().apply {
         parameters.apply {

--- a/src/common/src/com/jinxservers/alphavantage/forex/request/DailyRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/forex/request/DailyRequest.kt
@@ -2,21 +2,23 @@ package com.jinxservers.alphavantage.forex.request
 
 import com.jinxservers.alphavantage.Request
 import com.jinxservers.alphavantage.forex.response.ForexDaily
-import com.jinxservers.alphavantage.forex.response.ForexIntraday
 import com.jinxservers.alphavantage.util.OutputSize
 import io.ktor.http.*
 
 internal class DailyRequest(
     fromSymbol: String,
     toSymbol: String,
-    outputSize: OutputSize = OutputSize.COMPACT
+    outputSize: OutputSize?
 ) : Request<ForexDaily>(
     urlBuilder = URLBuilder().apply {
         parameters.apply {
             append("function", "FX_DAILY")
             append("from_symbol", fromSymbol)
             append("to_symbol", toSymbol)
-            append("outputsize", outputSize.size)
+
+            if (outputSize != null) {
+                append("outputsize", outputSize.size)
+            }
         }
     }
 )

--- a/src/common/src/com/jinxservers/alphavantage/forex/request/IntradayRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/forex/request/IntradayRequest.kt
@@ -9,16 +9,20 @@ import io.ktor.http.*
 internal class IntradayRequest(
     fromSymbol: String,
     toSymbol: String,
-    interval: ShortInterval,
-    outputSize: OutputSize = OutputSize.COMPACT
+    interval: ShortInterval?,
+    outputSize: OutputSize?
 ) : Request<ForexIntraday>(
     urlBuilder = URLBuilder().apply {
         parameters.apply {
             append("function", "FX_INTRADAY")
             append("from_symbol", fromSymbol)
             append("to_symbol", toSymbol)
-            append("interval", interval.value())
-            append("outputsize", outputSize.size)
+            if (interval != null) {
+                append("interval", interval.value())
+            }
+            if (outputSize != null) {
+                append("outputsize", outputSize.size)
+            }
         }
     }
 )

--- a/src/common/src/com/jinxservers/alphavantage/forex/request/IntradayRequest.kt
+++ b/src/common/src/com/jinxservers/alphavantage/forex/request/IntradayRequest.kt
@@ -9,8 +9,8 @@ import io.ktor.http.*
 internal class IntradayRequest(
     fromSymbol: String,
     toSymbol: String,
-    interval: ShortInterval?,
-    outputSize: OutputSize?
+    interval: ShortInterval? = null,
+    outputSize: OutputSize? = null
 ) : Request<ForexIntraday>(
     urlBuilder = URLBuilder().apply {
         parameters.apply {


### PR DESCRIPTION
Currently in the backend all of the requests prefill optional query parameters. This update will ensure that query parameters are only filled when supplied as arguments to the requesting function.